### PR TITLE
Implement tree table inspection view for `Dictionary` and `OrderedDictionary`

### DIFF
--- a/src/PatternBuffer-Tests/DictionaryTest.extension.st
+++ b/src/PatternBuffer-Tests/DictionaryTest.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'DictionaryTest' }
 
 { #category : '*PatternBuffer-Tests' }
-DictionaryTest >> testInspectionItems [
+DictionaryTest >> testInspectionTreeTable [
 
 	| dict |
 	dict := Dictionary newFrom: {
@@ -10,6 +10,6 @@ DictionaryTest >> testInspectionItems [
 			        ('char' -> '*') }.
 
 	self
-		assert: (dict inspectionItems: SpPresenter new) class
+		assert: (dict inspectionTreeTable: SpPresenter new) class
 		equals: SpTreeTablePresenter
 ]

--- a/src/PatternBuffer-Tests/DictionaryTest.extension.st
+++ b/src/PatternBuffer-Tests/DictionaryTest.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : 'DictionaryTest' }
+
+{ #category : '*PatternBuffer-Tests' }
+DictionaryTest >> testInspectionTree [
+
+	| dict |
+	dict := Dictionary newFrom: {
+			        ('dec' -> 42).
+			        ('hex' -> '2a').
+			        ('char' -> '*') }.
+
+	self
+		assert: (dict inspectionTree: SpPresenter new) class
+		equals: SpTreeTablePresenter
+]

--- a/src/PatternBuffer-Tests/DictionaryTest.extension.st
+++ b/src/PatternBuffer-Tests/DictionaryTest.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'DictionaryTest' }
 
 { #category : '*PatternBuffer-Tests' }
-DictionaryTest >> testInspectionTree [
+DictionaryTest >> testInspectionItems [
 
 	| dict |
 	dict := Dictionary newFrom: {
@@ -10,6 +10,6 @@ DictionaryTest >> testInspectionTree [
 			        ('char' -> '*') }.
 
 	self
-		assert: (dict inspectionTree: SpPresenter new) class
+		assert: (dict inspectionItems: SpPresenter new) class
 		equals: SpTreeTablePresenter
 ]

--- a/src/PatternBuffer-Tests/OrderedDictionaryTest.extension.st
+++ b/src/PatternBuffer-Tests/OrderedDictionaryTest.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'OrderedDictionaryTest' }
 
 { #category : '*PatternBuffer-Tests' }
-OrderedDictionaryTest >> testInspectionItems [
+OrderedDictionaryTest >> testInspectionTreeTable [
 
 	| orderedDict |
 	orderedDict := OrderedDictionary newFrom: {
@@ -10,6 +10,6 @@ OrderedDictionaryTest >> testInspectionItems [
 			               ('char' -> '*') }.
 
 	self
-		assert: (orderedDict inspectionItems: SpPresenter new) class
+		assert: (orderedDict inspectionTreeTable: SpPresenter new) class
 		equals: SpTreeTablePresenter
 ]

--- a/src/PatternBuffer-Tests/OrderedDictionaryTest.extension.st
+++ b/src/PatternBuffer-Tests/OrderedDictionaryTest.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'OrderedDictionaryTest' }
 
 { #category : '*PatternBuffer-Tests' }
-OrderedDictionaryTest >> testInspectionTree [
+OrderedDictionaryTest >> testInspectionItems [
 
 	| orderedDict |
 	orderedDict := OrderedDictionary newFrom: {
@@ -10,6 +10,6 @@ OrderedDictionaryTest >> testInspectionTree [
 			               ('char' -> '*') }.
 
 	self
-		assert: (orderedDict inspectionTree: SpPresenter new) class
+		assert: (orderedDict inspectionItems: SpPresenter new) class
 		equals: SpTreeTablePresenter
 ]

--- a/src/PatternBuffer-Tests/OrderedDictionaryTest.extension.st
+++ b/src/PatternBuffer-Tests/OrderedDictionaryTest.extension.st
@@ -1,0 +1,15 @@
+Extension { #name : 'OrderedDictionaryTest' }
+
+{ #category : '*PatternBuffer-Tests' }
+OrderedDictionaryTest >> testInspectionTree [
+
+	| orderedDict |
+	orderedDict := OrderedDictionary newFrom: {
+			               ('dec' -> 42).
+			               ('hex' -> '2a').
+			               ('char' -> '*') }.
+
+	self
+		assert: (orderedDict inspectionTree: SpPresenter new) class
+		equals: SpTreeTablePresenter
+]

--- a/src/PatternBuffer/Dictionary.extension.st
+++ b/src/PatternBuffer/Dictionary.extension.st
@@ -1,0 +1,28 @@
+Extension { #name : 'Dictionary' }
+
+{ #category : '*PatternBuffer' }
+Dictionary >> inspectionTree: aBuilder [
+
+	<inspectorPresentationOrder: -1 title: 'Items'>
+	^ aBuilder newTreeTable
+		  addColumn: (SpStringTableColumn new
+				   title: 'Key';
+				   evaluated: [ :each |
+					   StObjectPrinter asTruncatedTextFrom: each key ];
+				   width: 150;
+				   beSortable);
+		  addColumn: (SpStringTableColumn
+				   title: 'Value'
+				   evaluated: [ :each |
+				   StObjectPrinter asTruncatedTextFrom: each value ]) beSortable;
+		  items: (self associations collect: [ :e |
+				   PBDictionaryInspectorAssociationNode hostObject: e ]);
+		  children: [ :each | each children ];
+		  yourself
+]
+
+{ #category : '*PatternBuffer' }
+Dictionary >> inspectorDictionaryNodes [
+
+	^ (PBDictionaryNodeCollector for: self) collectNodes
+]

--- a/src/PatternBuffer/Dictionary.extension.st
+++ b/src/PatternBuffer/Dictionary.extension.st
@@ -1,9 +1,9 @@
 Extension { #name : 'Dictionary' }
 
 { #category : '*PatternBuffer' }
-Dictionary >> inspectionItems: aBuilder [
+Dictionary >> inspectionTreeTable: aBuilder [
 
-	<inspectorPresentationOrder: -1 title: 'Items'>
+	<inspectorPresentationOrder: -1 title: 'Tree'>
 	^ aBuilder newTreeTable
 		  addColumn: (SpStringTableColumn new
 				   title: 'Key';

--- a/src/PatternBuffer/Dictionary.extension.st
+++ b/src/PatternBuffer/Dictionary.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'Dictionary' }
 
 { #category : '*PatternBuffer' }
-Dictionary >> inspectionTree: aBuilder [
+Dictionary >> inspectionItems: aBuilder [
 
 	<inspectorPresentationOrder: -1 title: 'Items'>
 	^ aBuilder newTreeTable

--- a/src/PatternBuffer/OrderedDictionary.extension.st
+++ b/src/PatternBuffer/OrderedDictionary.extension.st
@@ -1,0 +1,22 @@
+Extension { #name : 'OrderedDictionary' }
+
+{ #category : '*PatternBuffer' }
+OrderedDictionary >> inspectionTree: aBuilder [
+
+	<inspectorPresentationOrder: -1 title: 'Items'>
+	^ aBuilder newTreeTable
+		  addColumn: (SpStringTableColumn new
+				   title: 'Key';
+				   evaluated: [ :each |
+					   StObjectPrinter asTruncatedTextFrom: each key ];
+				   width: 150;
+				   beSortable);
+		  addColumn: (SpStringTableColumn
+				   title: 'Value'
+				   evaluated: [ :each |
+				   StObjectPrinter asTruncatedTextFrom: each value ]) beSortable;
+		  items: (self associations collect: [ :e |
+				   PBDictionaryInspectorAssociationNode hostObject: e ]);
+		  children: [ :each | each children ];
+		  yourself
+]

--- a/src/PatternBuffer/OrderedDictionary.extension.st
+++ b/src/PatternBuffer/OrderedDictionary.extension.st
@@ -1,9 +1,9 @@
 Extension { #name : 'OrderedDictionary' }
 
 { #category : '*PatternBuffer' }
-OrderedDictionary >> inspectionItems: aBuilder [
+OrderedDictionary >> inspectionTreeTable: aBuilder [
 
-	<inspectorPresentationOrder: -1 title: 'Items'>
+	<inspectorPresentationOrder: -1 title: 'Tree'>
 	^ aBuilder newTreeTable
 		  addColumn: (SpStringTableColumn new
 				   title: 'Key';

--- a/src/PatternBuffer/OrderedDictionary.extension.st
+++ b/src/PatternBuffer/OrderedDictionary.extension.st
@@ -1,7 +1,7 @@
 Extension { #name : 'OrderedDictionary' }
 
 { #category : '*PatternBuffer' }
-OrderedDictionary >> inspectionTree: aBuilder [
+OrderedDictionary >> inspectionItems: aBuilder [
 
 	<inspectorPresentationOrder: -1 title: 'Items'>
 	^ aBuilder newTreeTable

--- a/src/PatternBuffer/PBDictionaryInspectorAssociationNode.class.st
+++ b/src/PatternBuffer/PBDictionaryInspectorAssociationNode.class.st
@@ -1,0 +1,15 @@
+"
+I model an attribute of a Dictionary in the StInspector. I am used in the Raw presentation of a Dictionary.
+"
+Class {
+	#name : 'PBDictionaryInspectorAssociationNode',
+	#superclass : 'StInspectorAssociationNode',
+	#category : 'PatternBuffer',
+	#package : 'PatternBuffer'
+}
+
+{ #category : 'accessing' }
+PBDictionaryInspectorAssociationNode >> children [
+
+	^ self value inspectorDictionaryNodes
+]

--- a/src/PatternBuffer/PBDictionaryNodeCollector.class.st
+++ b/src/PatternBuffer/PBDictionaryNodeCollector.class.st
@@ -1,0 +1,16 @@
+"
+I am a tool to collect Dictionary inspection nodes.
+"
+Class {
+	#name : 'PBDictionaryNodeCollector',
+	#superclass : 'StNodeCollector',
+	#category : 'PatternBuffer',
+	#package : 'PatternBuffer'
+}
+
+{ #category : 'building' }
+PBDictionaryNodeCollector >> collectNodes [
+
+	^ self object associations collect: [ :assoc |
+		  PBDictionaryInspectorAssociationNode hostObject: assoc ]
+]

--- a/src/PatternBuffer/ProtoObject.extension.st
+++ b/src/PatternBuffer/ProtoObject.extension.st
@@ -1,0 +1,7 @@
+Extension { #name : 'ProtoObject' }
+
+{ #category : '*PatternBuffer' }
+ProtoObject >> inspectorDictionaryNodes [
+
+	^ self inspectorNodes
+]


### PR DESCRIPTION
Adds a tree table view of key-value pairs in the inspection pane.

Implementation inspired by [Dictionary>>gtItemsFor:](https://github.com/feenkcom/gtoolkit-inspector/blob/b3e5ace70fd803cceda09500ee0f9e1f9d5ba029/src/GToolkit-Inspector/Dictionary.extension.st#L141)

Special thanks to [Gabriel Darbord](https://github.com/Gabriel-Darbord/) for code contribution <3

closes #19 

<img width="1412" height="821" alt="Screenshot from 2026-09-02 14-40-11" src="https://github.com/user-attachments/assets/c990bee1-25b1-4499-8a4a-fe57ce6c37b9" />
